### PR TITLE
text-embedding-ada-002 の評価結果を追加

### DIFF
--- a/9_text-embedding-ada-002.ipynb
+++ b/9_text-embedding-ada-002.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install openai[embeddings]==0.27.2\n",
+    "\n",
+    "import openai\n",
+    "openai.api_key = \"sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai.embeddings_utils import get_embeddings"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JSTS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sentence_pair_id</th>\n",
+       "      <th>yjcaptions_id</th>\n",
+       "      <th>sentence1</th>\n",
+       "      <th>sentence2</th>\n",
+       "      <th>label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>100312_421853-104611-31624</td>\n",
+       "      <td>レンガの建物の前を、乳母車を押した女性が歩いています。</td>\n",
+       "      <td>厩舎で馬と女性とが寄り添っています。</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  sentence_pair_id               yjcaptions_id                    sentence1  \\\n",
+       "0                0  100312_421853-104611-31624  レンガの建物の前を、乳母車を押した女性が歩いています。   \n",
+       "\n",
+       "            sentence2  label  \n",
+       "0  厩舎で馬と女性とが寄り添っています。    0.0  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "from urllib.request import urlopen\n",
+    "jsts_url = \"https://raw.githubusercontent.com/yahoojapan/JGLUE/main/datasets/jsts-v1.1/valid-v1.1.json\"\n",
+    "df = pd.DataFrame([json.loads(line) for line in urlopen(jsts_url).readlines()])\n",
+    "df.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1457, 5)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Encode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1457, 1536), (1457, 1536))"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "sentence1_embs = np.array(get_embeddings(df[\"sentence1\"], engine=\"text-embedding-ada-002\"))\n",
+    "sentence2_embs = np.array(get_embeddings(df[\"sentence2\"], engine=\"text-embedding-ada-002\"))\n",
+    "sentence1_embs.shape, sentence2_embs.shape"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Correlation Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.7900689629242748"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from scipy.spatial.distance import cosine\n",
+    "from scipy.stats import spearmanr\n",
+    "df[\"similarity\"] = [1 - cosine(s1, s2) for s1, s2 in zip(sentence1_embs, sentence2_embs)]\n",
+    "spearmanr(df[\"similarity\"], df[\"label\"])[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JSICK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pair_ID</th>\n",
+       "      <th>data</th>\n",
+       "      <th>sentence_A_En</th>\n",
+       "      <th>sentence_B_En</th>\n",
+       "      <th>entailment_label_En</th>\n",
+       "      <th>relatedness_score_En</th>\n",
+       "      <th>corr_entailment_labelAB_En</th>\n",
+       "      <th>corr_entailment_labelBA_En</th>\n",
+       "      <th>sentence_A_Ja</th>\n",
+       "      <th>sentence_B_Ja</th>\n",
+       "      <th>entailment_label_Ja</th>\n",
+       "      <th>relatedness_score_Ja</th>\n",
+       "      <th>image_ID</th>\n",
+       "      <th>original_caption</th>\n",
+       "      <th>semtag_short</th>\n",
+       "      <th>semtag_long</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>6</td>\n",
+       "      <td>test</td>\n",
+       "      <td>There is no boy playing outdoors and there is ...</td>\n",
+       "      <td>A group of kids is playing in a yard and an ol...</td>\n",
+       "      <td>neutral</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>戸外で遊んでいる男の子は一人もおらず、微笑んでいる男性は一人もいない</td>\n",
+       "      <td>子供たちのグループが庭で遊んでいて、後ろの方には年を取った男性が立っている</td>\n",
+       "      <td>contradiction</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>3155657768_b83a7831e5.jpg</td>\n",
+       "      <td>The children are playing outdoors , while a ma...</td>\n",
+       "      <td>Negation#Numerical</td>\n",
+       "      <td>Numerical;人;名詞,接尾,助数詞,*#Negation;ない;助動詞,*,*,*#...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pair_ID  data                                      sentence_A_En  \\\n",
+       "0        6  test  There is no boy playing outdoors and there is ...   \n",
+       "\n",
+       "                                       sentence_B_En entailment_label_En  \\\n",
+       "0  A group of kids is playing in a yard and an ol...             neutral   \n",
+       "\n",
+       "   relatedness_score_En corr_entailment_labelAB_En corr_entailment_labelBA_En  \\\n",
+       "0                   3.3                        NaN                        NaN   \n",
+       "\n",
+       "                        sentence_A_Ja                          sentence_B_Ja  \\\n",
+       "0  戸外で遊んでいる男の子は一人もおらず、微笑んでいる男性は一人もいない  子供たちのグループが庭で遊んでいて、後ろの方には年を取った男性が立っている   \n",
+       "\n",
+       "  entailment_label_Ja  relatedness_score_Ja                   image_ID  \\\n",
+       "0       contradiction                   2.3  3155657768_b83a7831e5.jpg   \n",
+       "\n",
+       "                                    original_caption        semtag_short  \\\n",
+       "0  The children are playing outdoors , while a ma...  Negation#Numerical   \n",
+       "\n",
+       "                                         semtag_long  \n",
+       "0  Numerical;人;名詞,接尾,助数詞,*#Negation;ない;助動詞,*,*,*#...  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(\"https://github.com/verypluming/JSICK/raw/main/jsick/test.tsv\", sep=\"\\t\")\n",
+    "df.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4927, 16)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((4927, 1536), (4927, 1536))"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sentence1_embs = []\n",
+    "sentence2_embs = []\n",
+    "\n",
+    "for batch_index in range(0, len(df[\"sentence_A_Ja\"]), 2048):\n",
+    "    cur_sentence1_list = df[\"sentence_A_Ja\"][batch_index:batch_index+2048]\n",
+    "    cur_sentence2_list = df[\"sentence_B_Ja\"][batch_index:batch_index+2048]\n",
+    "    \n",
+    "    cur_sentence1_embs = get_embeddings(cur_sentence1_list, engine=\"text-embedding-ada-002\")\n",
+    "    cur_sentence2_embs = get_embeddings(cur_sentence2_list, engine=\"text-embedding-ada-002\")\n",
+    "    \n",
+    "    sentence1_embs.extend(cur_sentence1_embs)\n",
+    "    sentence2_embs.extend(cur_sentence2_embs)\n",
+    "    \n",
+    "sentence1_embs = np.array(sentence1_embs)\n",
+    "sentence2_embs = np.array(sentence2_embs)\n",
+    "\n",
+    "sentence1_embs.shape, sentence2_embs.shape"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Correlation Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.7894255862324263"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from scipy.spatial.distance import cosine\n",
+    "from scipy.stats import spearmanr\n",
+    "df[\"similarity\"] = [1 - cosine(s1, s2) for s1, s2 in zip(sentence1_embs, sentence2_embs)]\n",
+    "spearmanr(df[\"similarity\"], df[\"relatedness_score_Ja\"])[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cosine similarity was used to calculate the similarity of sentence pairs.
 | pkshatech/simcse-ja-bert-base-clcmlp | 0.8014       | 0.7345      |
 | universal-sentence-encoder-multilingual-large-3 | 0.8014       | 0.8232      |
 | universal-sentence-encoder-multilingual-3 | 0.7899       | 0.8003      |
+| text-embedding-ada-002 | 0.7900 | 0.7894 |
 
 ## Models
 
@@ -24,6 +25,7 @@ Cosine similarity was used to calculate the similarity of sentence pairs.
 6. https://huggingface.co/pkshatech/simcse-ja-bert-base-clcmlp
 7. https://tfhub.dev/google/universal-sentence-encoder-multilingual-large/3
 8. https://tfhub.dev/google/universal-sentence-encoder-multilingual/3
+9. https://platform.openai.com/docs/guides/embeddings
 
 ## Datasets
 


### PR DESCRIPTION
OpenAIのEmbeddingモデル text-embedding-ada-002 の性能が気になったので評価してみました。

| Model | JSTS valid-v1.1 | JSICK test |
| :---         |          ---:  |          ---: |
| text-embedding-ada-002 | 0.7900 | 0.7894 |

USEよりはスコアが低いですが、悪くはない気がします。