### PR TITLE
Add MIRACL evaluation for textembedding-gecko-multilingual@001

### DIFF
--- a/19_textembedding-gecko-multilingual@001.ipynb
+++ b/19_textembedding-gecko-multilingual@001.ipynb
@@ -26,7 +26,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 1,
       "metadata": {
         "id": "pyxkH1gepOz8"
       },
@@ -40,7 +40,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": 2,
       "metadata": {
         "id": "v1wHhnkqoRVm"
       },
@@ -62,7 +62,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": 13,
       "metadata": {
         "id": "gxh87Y_kqjs_"
       },
@@ -74,15 +74,15 @@
         "# https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings#model_versions\n",
         "model = TextEmbeddingModel.from_pretrained(\"textembedding-gecko-multilingual@001\")\n",
         "\n",
-        "def get_embeddings(sentences: list[str]) -> np.ndarray:\n",
-        "    embeddings = model.get_embeddings(sentences, auto_truncate=False)\n",
+        "def get_embeddings(sentences: list[str], auto_truncate: bool = False) -> np.ndarray:\n",
+        "    embeddings = model.get_embeddings(sentences, auto_truncate=auto_truncate)\n",
         "    return np.array([embedding.values for embedding in embeddings])\n",
         "\n",
-        "def batch_process_embeddings(sentences: list[str], batch_size: int = 5) -> np.ndarray:\n",
+        "def batch_process_embeddings(sentences: list[str], batch_size: int = 5, auto_truncate: bool = False) -> np.ndarray:\n",
         "    all_embeddings = []\n",
         "    for i in range(0, len(sentences), batch_size):\n",
         "        batch_sentences = sentences[i:i + batch_size]\n",
-        "        batch_embeddings = get_embeddings(batch_sentences)\n",
+        "        batch_embeddings = get_embeddings(batch_sentences, auto_truncate=auto_truncate)\n",
         "        all_embeddings.append(batch_embeddings)\n",
         "\n",
         "    return np.vstack(all_embeddings)\n"
@@ -315,18 +315,169 @@
         "id": "elXBsNYk7oGY"
       },
       "source": [
-        "# Miracle"
+        "# Miracle\n",
+        "* Need access token for huggingface"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 39,
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "miracle_n_hard_negs = 300\n",
+        "miracle_n_recall = 30\n",
+        "query_prefix = \"\"\n",
+        "passage_prefix = \"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
         "id": "ghINCDBH7qZj"
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import os\n",
+        "import dotenv\n",
+        "\n",
+        "dotenv.load_dotenv(\"huggingface_access_token\", override=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
-        "None\n"
+        "import datasets\n",
+        "\n",
+        "# query and positives\n",
+        "ds = datasets.load_dataset(\n",
+        "    \"miracl/miracl\", \"ja\", use_auth_token=os.environ[\"HF_ACCESS_TOKEN\"], split=\"dev\"\n",
+        ")\n",
+        "ds"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# all corpus texts\n",
+        "corpus = datasets.load_dataset(\"miracl/miracl-corpus\", \"ja\")\n",
+        "corpus"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "\n",
+        "# hard negatives\n",
+        "with open(\"./miracl_hard_negs_1000.json\") as f:\n",
+        "    hn = json.loads(f.read())\n",
+        "len(hn), list(hn.keys())[:5], hn[\"0\"].keys(), hn[\"0\"][\"docids\"][:2], hn[\"0\"][\"indices\"][\n",
+        "    :2\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from scipy.spatial.distance import cdist\n",
+        "\n",
+        "\n",
+        "def get_text(corpus_item):\n",
+        "    return corpus_item[\"title\"] + \" \" + corpus_item[\"text\"]\n",
+        "\n",
+        "\n",
+        "corpus_dict = {item[\"docid\"]: get_text(item) for item in corpus[\"train\"]}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(195, 156, 0.8)"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "n_total_pos = 0\n",
+        "n_total_tp = 0\n",
+        "\n",
+        "# only evaluate first 100 queries\n",
+        "for item in ds.select(range(100)):\n",
+        "    # query\n",
+        "    query_emb = get_embeddings([query_prefix + item[\"query\"]])\n",
+        "\n",
+        "    # passages are set(300 hard negatives + positives)\n",
+        "    positive_docids = [pp[\"docid\"] for pp in item[\"positive_passages\"]]\n",
+        "    positive_texts = [get_text(pp) for pp in item[\"positive_passages\"]]\n",
+        "    hn_docids = hn[item[\"query_id\"]][\"docids\"][:miracle_n_hard_negs]\n",
+        "\n",
+        "    # drop hard negatives in positives\n",
+        "    hn_docids = [docid for docid in hn_docids if docid not in positive_docids]\n",
+        "\n",
+        "    # search target\n",
+        "    target_docids = positive_docids + hn_docids\n",
+        "    target_texts = positive_texts + [corpus_dict[docid] for docid in hn_docids]\n",
+        "\n",
+        "    # embedding\n",
+        "    tmppath = f'tmp/textembedding-gecko-multilingual@001_{item[\"query_id\"]}.npy'\n",
+        "    if os.path.exists(tmppath):\n",
+        "        target_embs = np.load(tmppath)\n",
+        "    else:\n",
+        "        # use cache\n",
+        "        target_embs = batch_process_embeddings([passage_prefix + text for text in target_texts], auto_truncate=True)\n",
+        "        np.save(tmppath, target_embs)\n",
+        "\n",
+        "    # topK\n",
+        "    topk_indices = np.argsort(cdist(query_emb, target_embs, metric=\"cosine\"))[0][\n",
+        "        :miracle_n_recall\n",
+        "    ]\n",
+        "\n",
+        "    n_pos = len(positive_docids)\n",
+        "    n_tp = len(\n",
+        "        set(topk_indices) & set(range(len(positive_docids)))\n",
+        "    )  # positives are first indices\n",
+        "\n",
+        "    n_total_pos += n_pos\n",
+        "    n_total_tp += n_tp\n",
+        "\n",
+        "miracl_recall = n_total_tp / n_total_pos\n",
+        "\n",
+        "n_total_pos, n_total_tp, miracl_recall"
       ]
     },
     {
@@ -340,7 +491,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -355,10 +506,10 @@
               "('textembedding-gecko-multilingual@001',\n",
               " 0.8006039095558688,\n",
               " 0.803561121302977,\n",
-              " None)"
+              " 0.8)"
             ]
           },
-          "execution_count": 41,
+          "execution_count": 15,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -367,8 +518,7 @@
         "model_id = \"textembedding-gecko-multilingual@001\"\n",
         "jsts_score = 0.8006039095558688\n",
         "jsick_score = 0.803561121302977\n",
-        "# Not calculated from a cost perspective.\n",
-        "miracl_recall = None\n",
+        "miracl_recall = 0.8\n",
         "model_id, jsts_score, jsick_score, miracl_recall\n"
       ]
     },
@@ -405,7 +555,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.2"
     }
   },
   "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | text-embedding-3-large                          |             0.838 |        0.812 |        0.841[^1] |     0.830 |
 | text-embedding-3-small                          |             0.781 |        0.804 |        0.795[^1] |     0.793 |
 | text-embedding-ada-002                          |             0.790 |        0.790 |        0.728[^1] |     0.769 |
-| textembedding-gecko-multilingual@001            |             0.801 |        0.804 |              |           |
+| textembedding-gecko-multilingual@001            |             0.801 |        0.804 |        0.800[^1] |     0.801 |
 | LLM|
 | intfloat/e5-mistral-7b-instruct                 |             0.836 |        0.836 |    0.885[^2] |     0.852 |
 | oshizo/japanese-e5-mistral-7b_slerp             |             0.846 |        0.842 |    0.886[^2] |     0.858 |

--- a/scores/textembedding-gecko-multilingual@001.txt
+++ b/scores/textembedding-gecko-multilingual@001.txt
@@ -1,0 +1,1 @@
+{"model_id": "textembedding-gecko-multilingual@001", "jsts": 0.8006039095558688, "jsick": 0.803561121302977, "miracl": 0.8}


### PR DESCRIPTION
Thank you for this very useful repository!
I have added an evaluation of MIRACL to the textembedding-gecko-multilingual@001.
The evaluation was conducted using only the first 100 queries. The result (recall@30) was 0.8.

The source code for the evaluation with MIRACL was based on 22_text-embedding-3-small_1536.ipynb.
Please consider merging it if you find it suitable.
