### PR TITLE
add JaColBERTv2

### DIFF
--- a/28_bclavie_JaColBERTv2.ipynb
+++ b/28_bclavie_JaColBERTv2.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-07T08:50:45.949996Z",
+     "start_time": "2023-10-07T08:50:44.497041Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import os\n",
+    "\n",
+    "torch.cuda.is_available()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/share/miniconda/envs/mcol/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ragatouille import RAGPretrainedModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-07T08:50:45.965421Z",
+     "start_time": "2023-10-07T08:50:45.951998Z"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "miracle_n_hard_negs = 300\n",
+    "miracle_n_recall = 30"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "model_id = \"bclavie/JaColBERTv2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "JaColBERT = RAGPretrainedModel.from_pretrained(model_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Miracle\n",
+    "* Need access token for huggingface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import dotenv\n",
+    "\n",
+    "dotenv.load_dotenv(\"huggingface_access_token\", override=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/share/miniconda/envs/mcol/lib/python3.10/site-packages/datasets/load.py:1461: FutureWarning: The repository for miracl/miracl contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/miracl/miracl\n",
+      "You can avoid this message in future by passing the argument `trust_remote_code=True`.\n",
+      "Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.\n",
+      "  warnings.warn(\n",
+      "Generating dev split: 0 examples [00:00, ? examples/s]/usr/local/share/miniconda/envs/mcol/lib/python3.10/site-packages/datasets/load.py:1461: FutureWarning: The repository for miracl/miracl-corpus contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/miracl/miracl-corpus\n",
+      "You can avoid this message in future by passing the argument `trust_remote_code=True`.\n",
+      "Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.\n",
+      "  warnings.warn(\n",
+      "Generating dev split: 860 examples [04:19,  3.32 examples/s]\n",
+      "Generating testB split: 1141 examples [04:18,  4.41 examples/s]\n",
+      "Generating train split: 3477 examples [04:27, 13.00 examples/s]\n",
+      "Generating testA split: 650 examples [04:32,  2.39 examples/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Dataset({\n",
+       "    features: ['query_id', 'query', 'positive_passages', 'negative_passages'],\n",
+       "    num_rows: 860\n",
+       "})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import datasets\n",
+    "\n",
+    "# query and positives\n",
+    "ds = datasets.load_dataset(\n",
+    "    \"miracl/miracl\", \"ja\", split=\"dev\"\n",
+    ")\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatasetDict({\n",
+       "    train: Dataset({\n",
+       "        features: ['docid', 'title', 'text'],\n",
+       "        num_rows: 6953614\n",
+       "    })\n",
+       "})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# all corpus texts\n",
+    "corpus = datasets.load_dataset(\"miracl/miracl-corpus\", \"ja\")\n",
+    "corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(860,\n",
+       " ['0', '3', '4', '5', '7'],\n",
+       " dict_keys(['docids', 'indices']),\n",
+       " ['2681119#0', '2681119#1'],\n",
+       " [1393435, 1393436])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "# hard negatives\n",
+    "with open(\"./miracl_hard_negs_1000.json\") as f:\n",
+    "    hn = json.loads(f.read())\n",
+    "len(hn), list(hn.keys())[:5], hn[\"0\"].keys(), hn[\"0\"][\"docids\"][:2], hn[\"0\"][\"indices\"][\n",
+    "    :2\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 6953614/6953614 [04:41<00:00, 24717.64it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from scipy.spatial.distance import cdist\n",
+    "\n",
+    "\n",
+    "def get_text(corpus_item):\n",
+    "    return corpus_item[\"title\"] + \" \" + corpus_item[\"text\"]\n",
+    "\n",
+    "\n",
+    "corpus_dict = {item[\"docid\"]: get_text(item) for item in tqdm(corpus[\"train\"])}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 12%|█▏        | 99/860 [02:33<19:38,  1.55s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First 100 entries recall: 0.9179487179487179\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(195, 179, 0.9179487179487179)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_total_pos = 0\n",
+    "n_total_tp = 0\n",
+    "try:\n",
+    "    JaColBERT.clear_encoded_docs(force=True)\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "for i, item in enumerate(tqdm(ds)):    \n",
+    "    # passages are set(300 hard negatives + positives)\n",
+    "    positive_docids = [pp[\"docid\"] for pp in item[\"positive_passages\"]]\n",
+    "    positive_texts = [get_text(pp) for pp in item[\"positive_passages\"]]\n",
+    "    hn_docids = hn[item[\"query_id\"]][\"docids\"][:miracle_n_hard_negs]\n",
+    "\n",
+    "    # drop hard negatives in positives\n",
+    "    hn_docids = [docid for docid in hn_docids if docid not in positive_docids]\n",
+    "\n",
+    "    # search target\n",
+    "    target_texts = positive_texts + [corpus_dict[docid] for docid in hn_docids]\n",
+    "    metadata = [{\"pid\": _id} for _id in positive_docids + hn_docids]\n",
+    "\n",
+    "\n",
+    "    JaColBERT.encode(target_texts, document_metadatas=metadata, verbose=False)\n",
+    "\n",
+    "    results = JaColBERT.search_encoded_docs(item[\"query\"], k=miracle_n_recall)\n",
+    "\n",
+    "    topk_indices = [result['document_metadata']['pid'] for result in results]\n",
+    "\n",
+    "    n_pos = len(positive_docids)\n",
+    "    n_tp = len(\n",
+    "        set(topk_indices) & set((positive_docids))\n",
+    "    )  # positives are first indices\n",
+    "\n",
+    "    n_total_pos += n_pos\n",
+    "    n_total_tp += n_tp\n",
+    "\n",
+    "    JaColBERT.clear_encoded_docs(force=True)\n",
+    "    if i == 99:\n",
+    "        print(f\"First 100 entries recall: {n_total_tp / n_total_pos}\")\n",
+    "        break\n",
+    "miracl_recall = n_total_tp / n_total_pos\n",
+    "\n",
+    "n_total_pos, n_total_tp, miracl_recall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('bclavie/JaColBERTv2', None, None, 0.9179487179487179)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jsts_score = None\n",
+    "jsick_score = None\n",
+    "model_id, jsts_score, jsick_score, miracl_recall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(f'./scores/{model_id.replace(\"/\", \"_\")}.txt', \"w\") as f:\n",
+    "    f.write(\n",
+    "        json.dumps(\n",
+    "            {\n",
+    "                \"model_id\": model_id + '_first_100',\n",
+    "                \"jsts\": jsts_score,\n",
+    "                \"jsick\": jsick_score,\n",
+    "                \"miracl\": miracl_recall,\n",
+    "            }\n",
+    "        )\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "02c2702a58ea2fe60fd5f26dd152a70e7993d77024040a4f035d0ea16923b730"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | oshizo/japanese-e5-mistral-1.9b                 | 4096    | 1.9B      |             0.826 |        0.833 |        0.797 |     0.819 |
 | ColBERT|
 | bclavie/jacolbert_first_100 [^4]                | 128/token     | 111M      |                   |              |    0.872[^1] |           |
+| bclavie/JaColBERTv2 [^4]                | 128/token     | 111M      |                   |              |    0.918[^1] |           |
 | BAAI/bge-m3(colbert_vecs)                       | 1024/token    | 567M      |             0.799 |        0.798 |        0.917[^2] |     0.838 |
 | BAAI/bge-m3(colbert+sparse+dense)                       | 1024/token[^5]    | 567M      |             0.800 |        0.805 |        0.926 [^2] |     0.844 |
 

--- a/scores/bclavie_JaColBERTv2.txt
+++ b/scores/bclavie_JaColBERTv2.txt
@@ -1,0 +1,1 @@
+{"model_id": "bclavie/JaColBERTv2_first_100", "jsts": null, "jsick": null, "miracl": 0.9179487179487179}


### PR DESCRIPTION
Hello!

JaColBERTv2 (JaColBERTv1 + knowledge distillation) is out, so I've ran the benchmark (on the first 100 queries)!

In case it is useful for you when you rework the MIRACL evaluation as you mentioned, I've also generated & uploaded the top 1000 BM25 results for both MIRACL-dev and MR.TyDi-test to my website to fetch them easily:

Mr TyDi: https://ben.clavie.eu/retrieval/tydi_ja_bm25_top1000.json
MIRACL: https://ben.clavie.eu/retrieval/miracl_ja_bm25_top1000.json

(if you'd like, I'm also happy implementing NDCG to provide a less flawed metric than Recall in this context, though it is quite the computational overhead to rerun everything!)