### PR TITLE
Add hotchpotch/japanese-bge-reranker-v2-m3-v1

### DIFF
--- a/29_hotchpotch_japanese-bge-reranker-v2-m3-v1.ipynb
+++ b/29_hotchpotch_japanese-bge-reranker-v2-m3-v1.ipynb
@@ -369,7 +369,7 @@
     "    f.write(\n",
     "        json.dumps(\n",
     "            {\n",
-    "                \"model_id\": model_id + '_first_100',\n",
+    "                \"model_id\": model_id,\n",
     "                \"jsts\": jsts_score,\n",
     "                \"jsick\": jsick_score,\n",
     "                \"miracl\": miracl_recall,\n",

--- a/29_hotchpotch_japanese-bge-reranker-v2-m3-v1.ipynb
+++ b/29_hotchpotch_japanese-bge-reranker-v2-m3-v1.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-07T08:50:45.949996Z",
+     "start_time": "2023-10-07T08:50:44.497041Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import os\n",
+    "\n",
+    "torch.cuda.is_available()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sentence_transformers import CrossEncoder\n",
+    "import torch\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-07T08:50:45.965421Z",
+     "start_time": "2023-10-07T08:50:45.951998Z"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "miracle_n_hard_negs = 300\n",
+    "miracle_n_recall = 30"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "model_id = \"hotchpotch/japanese-bge-reranker-v2-m3-v1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "model = CrossEncoder(model_id, max_length=512, device=device)\n",
+    "if device == \"cuda\":\n",
+    "    model.model.half() # faster inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Miracle\n",
+    "* Need access token for huggingface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No module named 'dotenv'\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "try:\n",
+    "    import dotenv\n",
+    "    dotenv.load_dotenv(\"huggingface_access_token\", override=True)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/yu1/miniconda3/envs/py310/lib/python3.10/site-packages/datasets/load.py:1461: FutureWarning: The repository for miracl/miracl contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/miracl/miracl\n",
+      "You can avoid this message in future by passing the argument `trust_remote_code=True`.\n",
+      "Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Dataset({\n",
+       "    features: ['query_id', 'query', 'positive_passages', 'negative_passages'],\n",
+       "    num_rows: 860\n",
+       "})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import datasets\n",
+    "\n",
+    "# query and positives\n",
+    "ds = datasets.load_dataset(\n",
+    "    \"miracl/miracl\", \"ja\", split=\"dev\"\n",
+    ")\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/yu1/miniconda3/envs/py310/lib/python3.10/site-packages/datasets/load.py:1461: FutureWarning: The repository for miracl/miracl-corpus contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/miracl/miracl-corpus\n",
+      "You can avoid this message in future by passing the argument `trust_remote_code=True`.\n",
+      "Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DatasetDict({\n",
+       "    train: Dataset({\n",
+       "        features: ['docid', 'title', 'text'],\n",
+       "        num_rows: 6953614\n",
+       "    })\n",
+       "})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# all corpus texts\n",
+    "corpus = datasets.load_dataset(\"miracl/miracl-corpus\", \"ja\")\n",
+    "corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(860,\n",
+       " ['0', '3', '4', '5', '7'],\n",
+       " dict_keys(['docids', 'indices']),\n",
+       " ['2681119#0', '2681119#1'],\n",
+       " [1393435, 1393436])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "# hard negatives\n",
+    "with open(\"./miracl_hard_negs_1000.json\") as f:\n",
+    "    hn = json.loads(f.read())\n",
+    "len(hn), list(hn.keys())[:5], hn[\"0\"].keys(), hn[\"0\"][\"docids\"][:2], hn[\"0\"][\"indices\"][\n",
+    "    :2\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 6953614/6953614 [01:16<00:00, 90557.25it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from scipy.spatial.distance import cdist\n",
+    "\n",
+    "\n",
+    "def get_text(corpus_item):\n",
+    "    return corpus_item[\"title\"] + \" \" + corpus_item[\"text\"]\n",
+    "\n",
+    "\n",
+    "corpus_dict = {item[\"docid\"]: get_text(item) for item in tqdm(corpus[\"train\"])}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import transformers\n",
+    "# for \"Be aware, overflowing tokens are not returned for the setting you have chosen\" warning\n",
+    "transformers.logging.set_verbosity_error()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/860 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 860/860 [14:30<00:00,  1.01s/it]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(1790, 1695, 0.946927374301676)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_total_pos = 0\n",
+    "n_total_tp = 0\n",
+    "\n",
+    "for item in tqdm(ds, total=len(ds)):\n",
+    "    query = item[\"query\"]\n",
+    "    # passages are set(300 hard negatives + positives)\n",
+    "    positive_docids = [pp[\"docid\"] for pp in item[\"positive_passages\"]]\n",
+    "    positive_texts = [get_text(pp) for pp in item[\"positive_passages\"]]\n",
+    "    hn_docids = hn[item[\"query_id\"]][\"docids\"][:miracle_n_hard_negs]\n",
+    "\n",
+    "    # drop hard negatives in positives\n",
+    "    hn_docids = [docid for docid in hn_docids if docid not in positive_docids]\n",
+    "\n",
+    "    nagative_texts = [corpus_dict[docid] for docid in hn_docids]\n",
+    "    target_texts = positive_texts + nagative_texts\n",
+    "\n",
+    "    ranked = model.rank(query, target_texts, top_k=miracle_n_recall)\n",
+    "    ranked = [d['corpus_id'] for d in ranked]\n",
+    "    topk_indices = ranked\n",
+    "\n",
+    "    # topK\n",
+    "    n_pos = len(positive_docids)\n",
+    "    n_tp = len(\n",
+    "        set(topk_indices) & set(range(len(positive_docids)))\n",
+    "    )  # positives are first indices\n",
+    "\n",
+    "    n_total_pos += n_pos\n",
+    "    n_total_tp += n_tp\n",
+    "\n",
+    "    # if n_pos > n_tp:\n",
+    "    # print(f\"{item['query_id']}:{n_tp}/{n_pos}\", end=\", \")\n",
+    "\n",
+    "miracl_recall = n_total_tp / n_total_pos\n",
+    "\n",
+    "n_total_pos, n_total_tp, miracl_recall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('hotchpotch/japanese-bge-reranker-v2-m3-v1', None, None, 0.946927374301676)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jsts_score = None\n",
+    "jsick_score = None\n",
+    "model_id, jsts_score, jsick_score, miracl_recall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(f'./scores/{model_id.replace(\"/\", \"_\")}.txt', \"w\") as f:\n",
+    "    f.write(\n",
+    "        json.dumps(\n",
+    "            {\n",
+    "                \"model_id\": model_id + '_first_100',\n",
+    "                \"jsts\": jsts_score,\n",
+    "                \"jsick\": jsick_score,\n",
+    "                \"miracl\": miracl_recall,\n",
+    "            }\n",
+    "        )\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "02c2702a58ea2fe60fd5f26dd152a70e7993d77024040a4f035d0ea16923b730"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scores/hotchpotch_japanese-bge-reranker-v2-m3-v1.txt
+++ b/scores/hotchpotch_japanese-bge-reranker-v2-m3-v1.txt
@@ -1,1 +1,1 @@
-{"model_id": "hotchpotch/japanese-bge-reranker-v2-m3-v1_first_100", "jsts": null, "jsick": null, "miracl": 0.946927374301676}
+{"model_id": "hotchpotch/japanese-bge-reranker-v2-m3-v1", "jsts": null, "jsick": null, "miracl": 0.946927374301676}

--- a/scores/hotchpotch_japanese-bge-reranker-v2-m3-v1.txt
+++ b/scores/hotchpotch_japanese-bge-reranker-v2-m3-v1.txt
@@ -1,0 +1,1 @@
+{"model_id": "hotchpotch/japanese-bge-reranker-v2-m3-v1_first_100", "jsts": null, "jsick": null, "miracl": 0.946927374301676}


### PR DESCRIPTION
お世話になっております。

embeddings 評価なので、reranker は対象と違いそうだと思いつつも、JaColBERT 等での retrieve タスクも評価されているので、`hotchpotch/japanese-bge-reranker-v2-m3-v1` での retrieve タスク評価を追加してみました。

miracl は、マルチリンガルな他言語のtrainも学習したモデルでは、dev がかなり高評価になってしまうようですね…。